### PR TITLE
Renamed email references to username

### DIFF
--- a/app/src/main/java/com/example/habitapp/Activities/LogIn.java
+++ b/app/src/main/java/com/example/habitapp/Activities/LogIn.java
@@ -16,6 +16,7 @@
  *   1.1       Leah      Oct-30-2021   Added Firestore functionality
  *   1.2       Leah      Nov-02-2021   Fixed crash on blank field
  *   1.3       Eric      Nov-03-2021   Fixed other crashes on blank fields
+ *   1.4       Eric      Nov-04-2021   Renamed email references to username
  * =|=======|=|======|===|====|========|===========|================================================
  */
 
@@ -72,8 +73,8 @@ public class LogIn extends AppCompatActivity {
         db = FirebaseFirestore.getInstance();
 
         // get the Strings inside the editText views
-        EditText emailEdit = (EditText)findViewById(R.id.loginscreen_email);
-        String email = emailEdit.getText().toString();
+        EditText userNameEdit = (EditText)findViewById(R.id.loginscreen_username);
+        String username = userNameEdit.getText().toString();
         EditText passwordEdit = (EditText)findViewById(R.id.loginscreen_password);
         String password = passwordEdit.getText().toString();
 
@@ -87,13 +88,13 @@ public class LogIn extends AppCompatActivity {
         Context loginContext = this;
 
         // try obtaining a reference to the email field
-        if(email.isEmpty() || password.isEmpty()){
+        if(username.isEmpty() || password.isEmpty()){
             // username/password error
             loginAlert.setMessage("Please enter your username and password.");
             loginAlert.show();
         }
         else{
-            final DocumentReference findUserRef = db.collection("Doers").document(email);
+            final DocumentReference findUserRef = db.collection("Doers").document(username);
             findUserRef.get().addOnCompleteListener(new OnCompleteListener<DocumentSnapshot>() {
                 @Override
                 public void onComplete(@NonNull Task<DocumentSnapshot> task) {
@@ -110,7 +111,7 @@ public class LogIn extends AppCompatActivity {
                                 //  send a state through the intent bundle?
                                 Intent intent = new Intent(loginContext, Main.class);
                                 //
-                                intent.putExtra(MESSAGE, email);
+                                intent.putExtra(MESSAGE, username);
                                 // bundle the user info into Serializable and send through Intent
                                 intent.putExtra("userData",(Serializable) userData);
                                 // start Main Activity

--- a/app/src/main/java/com/example/habitapp/Activities/SignUp.java
+++ b/app/src/main/java/com/example/habitapp/Activities/SignUp.java
@@ -17,6 +17,7 @@
  *   1.2       Leah      Nov-01-2021   Removed test habit data.
  *   1.3       Leah      Nov-02-2021   Fixed crash on blank field
  *   1.4       Eric      Nov-03-2021   Fixed other crashes on blank fields
+ *   1.5       Eric      Nov-04-2021   Renamed email references to username
  * =|=======|=|======|===|====|========|===========|================================================
  */
 
@@ -77,8 +78,8 @@ public class SignUp extends AppCompatActivity {
 
         EditText getName = (EditText)findViewById(R.id.signupscreen_name_alias);
         String name = getName.getText().toString();
-        EditText getEmail = (EditText)findViewById(R.id.signupscreen_email);
-        String email = getEmail.getText().toString();
+        EditText getUsername = (EditText)findViewById(R.id.signupscreen_username);
+        String username = getUsername.getText().toString();
         EditText getPassword = (EditText)findViewById(R.id.signupscreen_password);
         String password = getPassword.getText().toString();
 
@@ -101,13 +102,13 @@ public class SignUp extends AppCompatActivity {
         Context signupContext = this;
 
         // try obtaining a reference to the email field
-        if(name.isEmpty() || email.isEmpty() || password.isEmpty()){
+        if(name.isEmpty() || username.isEmpty() || password.isEmpty()){
             // name/username/password error
             signupAlert.setMessage("Please enter your name, your username and, password.");
             signupAlert.show();
 
         } else {
-            final DocumentReference findUserRef = db.collection("Doers").document(email);
+            final DocumentReference findUserRef = db.collection("Doers").document(username);
             findUserRef.get().addOnCompleteListener(new OnCompleteListener<DocumentSnapshot>() {
                 @Override
                 public void onComplete(@NonNull Task<DocumentSnapshot> task) {
@@ -118,7 +119,7 @@ public class SignUp extends AppCompatActivity {
                             // TODO: initiate name and other user profile details here
                             // Must change habit format later
                             Map userData = new HashMap<>();
-                            userData.put("username",email);
+                            userData.put("username",username);
                             userData.put("password",password);
                             userData.put("name",name);
 
@@ -135,7 +136,7 @@ public class SignUp extends AppCompatActivity {
                                                 //  button to take the user back to the log in page
                                                 //  send a state through the intent bundle?
                                                 Intent intent = new Intent(signupContext, Main.class);
-                                                intent.putExtra(MESSAGE, email);
+                                                intent.putExtra(MESSAGE, username);
                                                 // bundle the user info into Serializable and send through Intent
                                                 intent.putExtra("userData",(Serializable) userData);
                                                 // start Main Activity

--- a/app/src/main/res/layout/log_in_screen.xml
+++ b/app/src/main/res/layout/log_in_screen.xml
@@ -83,13 +83,13 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="30dp"
         android:layout_marginTop="20dp"
-        android:text="Email"
+        android:text="Username"
         android:textSize="24sp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/textView7" />
 
     <EditText
-        android:id="@+id/loginscreen_email"
+        android:id="@+id/loginscreen_username"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="30dp"
@@ -110,7 +110,7 @@
         android:text="Password"
         android:textSize="24sp"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/loginscreen_email" />
+        app:layout_constraintTop_toBottomOf="@+id/loginscreen_username" />
 
     <EditText
         android:id="@+id/loginscreen_password"

--- a/app/src/main/res/layout/sign_up_screen.xml
+++ b/app/src/main/res/layout/sign_up_screen.xml
@@ -107,13 +107,13 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="30dp"
         android:layout_marginTop="10dp"
-        android:text="Email"
+        android:text="Username"
         android:textSize="24sp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/signupscreen_name_alias" />
 
     <EditText
-        android:id="@+id/signupscreen_email"
+        android:id="@+id/signupscreen_username"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="30dp"
@@ -134,7 +134,7 @@
         android:text="Password"
         android:textSize="24sp"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/signupscreen_email" />
+        app:layout_constraintTop_toBottomOf="@+id/signupscreen_username" />
 
     <EditText
         android:id="@+id/signupscreen_password"


### PR DESCRIPTION
Just changed the spots that say email in the app (in the log in and sign up frames) to say username instead. 👍